### PR TITLE
Move to fastmcp

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -6,7 +6,9 @@
             "args": [
                 "run",
                 "-m",
-                "atlas_mcp.server"
+                "atlas_mcp.server",
+                "--transport",
+                "stdio"
             ],
             // "envFile": "${workspaceFolder}/.env",
             // "dev": {

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # atlas-mcp
 
-Exploring `mcp` servers that are tuned to run against ATLAS infrastructure
+Exploring `fastmcp` servers that are tuned to run against ATLAS infrastructure
 
 ## Introduction
 
-This is a place to collect some tooling that uses an `mcp` interface to expose ATLAS metadata to an LLM. At the moment everything here is very experimental.
+This is a place to collect some tooling that uses a `fastmcp` interface to expose ATLAS metadata to an LLM. At the moment everything here is very experimental.
 
-THe current tools expose limited amounts from the following datasources:
+The current tools expose limited amounts from the following datasources:
 
 - AMI dataset metadata
 - Rucio
@@ -29,9 +29,45 @@ Preparation:
 
 In the agent mode, set the LLM to something like `GPT-5 mini` (no need to waste tokens, this is fairly simple work), and then `/data all-hadronic ttbar`. Grant it permission.
 
+### Command Line
+
+The server supports two transport modes:
+
+#### Stdio Transport (default)
+
+Used by VS Code and other MCP clients that spawn servers as subprocesses:
+
+```bash
+uv run -m atlas_mcp.server --transport stdio
+```
+
+This is the default mode and is automatically used when running via VS Code's MCP configuration.
+
+#### HTTP Transport
+
+For direct API access or web-based clients:
+
+```bash
+uv run -m atlas_mcp.server --transport http --port 8080
+```
+
+The server will be available at `http://localhost:8080/mcp`. You can customize the port with the `--port` flag (default: 8080).
+
+Example using curl to list available tools:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
+```
+
 ## Testing
 
-Use `mcp dev src/atlas_mcp/server.py` to run locally with the test web interface.
+Use `fastmcp dev src/atlas_mcp/server.py` to run locally with the test web interface (if available), or run tests with:
+
+```bash
+uv run pytest
+```
 
 ## Sample Run in `vscode`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,12 @@ authors = [{ name = "Gordon Watts", email = "gwatts@uw.edu" }]
 requires-python = ">=3.13"
 dependencies = [
     "diskcache>=5.6.3",
-    "mcp[cli]>=1.15.0",
+    "fastmcp",
     "pydantic>=2.11.9",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.2.0",
     "pytest-mock>=3.12.0",
+    "typer",
     "black",
     "flake8",
 ]

--- a/src/atlas_mcp/server.py
+++ b/src/atlas_mcp/server.py
@@ -1,7 +1,8 @@
 import json
 from typing import List
 
-from mcp.server.fastmcp import FastMCP
+import typer
+from fastmcp import FastMCP
 
 import atlas_mcp.central_page as cp
 
@@ -98,10 +99,32 @@ def get_metadata(
     return json.dumps(md)
 
 
-def main() -> None:
-    # stdio is the default; this runs the server loop
-    mcp.run()
+app = typer.Typer(help="ATLAS MCP Server")
+
+
+@app.command()
+def main(
+    transport: str = typer.Option(
+        "stdio",
+        "--transport",
+        help="Transport mode: stdio (default) or http",
+    ),
+    port: int = typer.Option(
+        8080,
+        "--port",
+        help="Port for HTTP transport (default: 8080)",
+    ),
+) -> None:
+    """Run the ATLAS MCP server with the specified transport."""
+    if transport not in ["stdio", "http"]:
+        typer.echo(f"Error: Invalid transport '{transport}'. Choose 'stdio' or 'http'.")
+        raise typer.Exit(1)
+
+    if transport == "stdio":
+        mcp.run(transport="stdio")
+    else:
+        mcp.run(transport="streamable-http", port=port, host="localhost")
 
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,8 +15,8 @@ def test_get_allowed_scopes(mocker):
     # Mock the central_page.get_allowed_scopes function
     mocker.patch("atlas_mcp.central_page.get_allowed_scopes", return_value=mock_scopes)
 
-    # Call the server function
-    result = server.get_allowed_scopes()
+    # Call the server function - access the underlying function from the FunctionTool
+    result = server.get_allowed_scopes.fn()
 
     # Verify the result is valid JSON
     parsed = json.loads(result)
@@ -60,8 +60,8 @@ def test_get_addresses_for_keyword_baseline_only(mocker):
         return_value=mock_addresses,
     )
 
-    # Call the server function with baseline_only=True (default)
-    result = server.get_addresses_for_keyword("mc23_13p6TeV", "Dijet")
+    # Call the server function with baseline_only=True (default) - access underlying function
+    result = server.get_addresses_for_keyword.fn("mc23_13p6TeV", "Dijet")
 
     # Verify the result is valid JSON
     parsed = json.loads(result)
@@ -105,8 +105,8 @@ def test_get_addresses_for_keyword_all_types(mocker):
         return_value=mock_addresses,
     )
 
-    # Call the server function with baseline_only=False
-    result = server.get_addresses_for_keyword(
+    # Call the server function with baseline_only=False - access underlying function
+    result = server.get_addresses_for_keyword.fn(
         "mc23_13p6TeV", "Dijet", baseline_only=False
     )
 
@@ -140,12 +140,11 @@ def test_get_metadata_tool(mocker):
 
     scope = "mc23_13p6TeV"
     dataset = "mc23_13p6TeV.123456.Pythia8...DAOD_PHYS.e8514_s4162_r14622_p5855"
-    result = server.get_metadata(scope, dataset, use_top_of_provenance=True)
+    # Access the underlying function from the FunctionTool
+    result = server.get_metadata.fn(scope, dataset, use_top_of_provenance=True)
 
     parsed = json.loads(result)
     assert parsed["Physics Comment"] == "NULL"
     assert parsed["Physics Short Name"] == "Py8EG_A14NNPDF23LO_jj_JZ9incl"
 
-    mocked.assert_called_once_with(
-        scope, dataset, use_top_of_provenance=True
-    )
+    mocked.assert_called_once_with(scope, dataset, use_top_of_provenance=True)


### PR DESCRIPTION
- Update references from `mcp` to `fastmcp` in documentation and code.
- Modify server command to support both `stdio` and `http` transport modes.
- Adjust dependencies to include `fastmcp` and remove `mcp[cli]`.
- Enhance command-line interface using `typer` for better user experience.
- Update tests to access underlying functions correctly.

Fixes #14