### PR TITLE
Add integration tests for AMI/Central Page services

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
         "ltlow",
         "NNPDF",
         "PHYSLITE",
+        "pytestmark",
         "rucio",
         "simul",
         "streamable",

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Use `fastmcp dev src/atlas_mcp/server.py` to run locally with the test web inter
 uv run pytest
 ```
 
+Integration tests that hit real AMI/Central Page services are gated behind a flag:
+
+```bash
+uv run pytest --integration
+```
+
+These require ATLAS credentials and a valid `voms-proxy-init` session on a host with `/cvmfs`.
+
 ## Sample Run in `vscode`
 
 This was kicked off with `/data all-hadronic ttbar`.

--- a/src/atlas_mcp/central_page.py
+++ b/src/atlas_mcp/central_page.py
@@ -224,9 +224,7 @@ def get_metadata(
     # metadata may not make sense.
     target_ds = full_dataset_name
     if use_top_of_provenance:
-        prov = ami.get_provenance(
-            scope, full_dataset_name, ignore_cache=ignore_cache
-        )
+        prov = ami.get_provenance(scope, full_dataset_name, ignore_cache=ignore_cache)
         if prov:
             target_ds = prov[-1]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,30 @@ from ami_helper.utils import ensure_and_import
 @pytest.fixture(autouse=True)
 def ensure_pyami_installed() -> None:
     ensure_and_import("pyAMI_atlas")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests that exercise real AMI/Central Page calls.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "integration: mark tests that require AMI/Central Page access",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if config.getoption("--integration"):
+        return
+    skip_integration = pytest.mark.skip(reason="need --integration to run")
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -1,0 +1,84 @@
+import json
+import re
+
+import pytest
+
+from atlas_mcp import server
+
+pytestmark = pytest.mark.integration
+
+SCOPE = "mc23_13p6TeV"
+KEYWORD = "ttbar"
+
+
+@pytest.fixture(scope="module")
+def central_page_address() -> dict:
+    result = server.get_addresses_for_keyword.fn(
+        SCOPE, KEYWORD, baseline_only=True, ignore_cache=True
+    )
+    parsed = json.loads(result)
+    assert parsed
+    return parsed[0]
+
+
+@pytest.fixture(scope="module")
+def evtgen_sample(central_page_address: dict) -> str:
+    result = server.get_evtgen_for_address.fn(
+        SCOPE, central_page_address["hash_tags"], ignore_cache=True
+    )
+    samples = json.loads(result)
+    assert samples
+    return samples[0]
+
+
+def test_get_allowed_scopes_integration():
+    result = server.get_allowed_scopes.fn(ignore_cache=True)
+    parsed = json.loads(result)
+    assert any(scope["scope"] == SCOPE for scope in parsed)
+
+
+def test_get_addresses_for_keyword_integration(central_page_address: dict):
+    assert central_page_address["scope"] == SCOPE
+    assert len(central_page_address["hash_tags"]) == 4
+    assert central_page_address["hash_tags"][2] == "Baseline"
+
+
+def test_get_evtgen_for_address_integration(evtgen_sample: str):
+    assert evtgen_sample.startswith(f"{SCOPE}.")
+    assert ".EVNT" in evtgen_sample
+
+
+def test_get_samples_for_run_integration(evtgen_sample: str):
+    dsid = evtgen_sample.split(".")[1]
+    assert re.fullmatch(r"\d+", dsid)
+    result = server.get_samples_for_run.fn(
+        SCOPE, dsid, data_tier="PHYSLITE", ignore_cache=True
+    )
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+
+
+def test_get_metadata_integration(evtgen_sample: str):
+    result = server.get_metadata.fn(
+        SCOPE,
+        evtgen_sample,
+        use_top_of_provenance=True,
+        ignore_cache=True,
+    )
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+    assert parsed
+
+
+def test_get_dataset_with_name_integration():
+    result = server.get_dataset_with_name.fn(
+        SCOPE, KEYWORD, is_central_page=True, ignore_cache=True
+    )
+    parsed = json.loads(result)
+    assert parsed
+    dataset_match = parsed[0]
+    assert dataset_match["name"].startswith(f"{SCOPE}.")
+    assert dataset_match["HashTag 1"]
+    assert dataset_match["HashTag 2"]
+    assert dataset_match["HashTag 3"]
+    assert dataset_match["HashTag 4"]


### PR DESCRIPTION
- Introduce integration tests that require real AMI/Central Page access.
- Add a command-line flag to enable integration tests.
- Include comments to clarify the purpose of the new flag.

Fixes #34